### PR TITLE
GEP-039: formatting issue

### DIFF
--- a/geps/0039-live-control-plane-migration/README.md
+++ b/geps/0039-live-control-plane-migration/README.md
@@ -157,7 +157,7 @@ For both source and destination seeds, the following resources are created:
 
 - A single `Gateway` resource.
 - A `VirtualService` per etcd member to perform host-based routing to the respective etcd member `Service`, and a `DestinationRule` per etcd member to configure traffic policies for those connections.
-- One `DNSRecord` per etcd member ( With domain name <etcd-pod-name>.<etcd-pod-namespace>.<seed-name>.<internal-domain>), each pointing to the `Seed` Istio `IngressGateway` loadbalancer, with traffic routed to the correct member via the corresponding `VirtualService`.
+- One `DNSRecord` per etcd member ( With domain name `<etcd-pod-name>.<etcd-pod-namespace>.<seed-name>.<internal-domain>`), each pointing to the `Seed` Istio `IngressGateway` loadbalancer, with traffic routed to the correct member via the corresponding `VirtualService`.
 
 #### Components with Shoot webhooks and Controllers reconciling shoot objects
 


### PR DESCRIPTION
Fixed formatting that is breaking the build for the documentation website. 

<!-- Please ensure that you do not include company internal information. -->

<!--
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. GEP-000: adding beta graduation criteria

	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the GEP status to
	implemented or GEP has been deprecated.
-->

<!--
Please select area and kind for this PR. This helps the community categorizing it.
Replace below TODOs with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
- How to categorize this PR:
/area documentation
/kind bug

<!-- short description of work done in PR e.g. updating milestone, adding new GEP, adding test requirements… -->
- One-line PR description:

Escaped angled brackets, since otherwise they are interpreted as HTML. As a bonus, I also think it looks better when rendered :)

<!-- link to the g/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments:
