### PR TITLE
Remove table of contents from enhancement proposals

### DIFF
--- a/geps/0001-gardener-extensibility/README.md
+++ b/geps/0001-gardener-extensibility/README.md
@@ -1,40 +1,5 @@
 # GEP-0001: Gardener Extensibility and Extraction of Cloud-Specific/OS-Specific Knowledge ([#308](https://github.com/gardener/gardener/issues/308), [#262](https://github.com/gardener/gardener/issues/262))
 
-## Table of Contents
-
-- [GEP-0001: Gardener Extensibility and Extraction of Cloud-Specific/OS-Specific Knowledge (#308, #262)](#gep-0001-gardener-extensibility-and-extraction-of-cloud-specificos-specific-knowledge-308-262)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Modification of Existing `CloudProfile` and `Shoot` Resources](#modification-of-existing-cloudprofile-and-shoot-resources)
-      - [CloudProfiles](#cloudprofiles)
-      - [Shoots](#shoots)
-    - [CRD Definitions and Workflow Adaptation](#crd-definitions-and-workflow-adaptation)
-      - [Custom Resource Definitions](#custom-resource-definitions)
-        - [DNS Records](#dns-records)
-        - [Infrastructure Provisioning](#infrastructure-provisioning)
-        - [Backup Infrastructure Provisioning](#backup-infrastructure-provisioning)
-        - [Cloud Config (User-Data) for Bootstrapping Machines](#cloud-config-user-data-for-bootstrapping-machines)
-        - [Worker Pools Definition](#worker-pools-definition)
-        - [Generic Resources](#generic-resources)
-      - [Shoot State](#shoot-state)
-      - [Shoot Health Checks/Conditions](#shoot-health-checksconditions)
-      - [Reconciliation Flow](#reconciliation-flow)
-      - [Deletion Flow](#deletion-flow)
-    - [gardenlet](#gardenlet)
-    - [Shoot Control Plane Movement/Migration](#shoot-control-plane-movementmigration)
-    - [BackupInfrastructure Migration](#backupinfrastructure-migration)
-  - [Registration of External Controllers at Gardener](#registration-of-external-controllers-at-gardener)
-  - [Other Cloud-Specific Parts](#other-cloud-specific-parts)
-    - [Defaulting and Validation Admission Plugins](#defaulting-and-validation-admission-plugins)
-    - [DNS Hosted Zone Admission Plugin](#dns-hosted-zone-admission-plugin)
-    - [Shoot Quota Admission Plugin](#shoot-quota-admission-plugin)
-    - [Shoot Maintenance Controller](#shoot-maintenance-controller)
-  - [Alternatives](#alternatives)
-
 ## Summary
 
 Gardener has evolved to a large compound of packages containing lots of highly specific knowledge, which makes it very hard to extend (supporting a new cloud provider, new OS, ..., or behaving differently depending on the underlying infrastructure).

--- a/geps/0004-core-gardener-cloud-api/README.md
+++ b/geps/0004-core-gardener-cloud-api/README.md
@@ -1,24 +1,5 @@
 # GEP-0004: New `core.gardener.cloud/v1beta1` APIs Required to Extract Cloud-Specific/OS-Specific Knowledge Out of Gardener Core
 
-## Table of Contents
-
-- [GEP-0004: New `core.gardener.cloud/v1beta1` APIs Required to Extract Cloud-Specific/OS-Specific Knowledge Out of Gardener Core](#gep-0004-new-coregardenercloudv1beta1-apis-required-to-extract-cloud-specificos-specific-knowledge-out-of-gardener-core)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [`CloudProfile` Resource](#cloudprofile-resource)
-    - [`Seed` Resource](#seed-resource)
-    - [`Project` Resource](#project-resource)
-    - [`SecretBinding` resource](#secretbinding-resource)
-    - [`Quota` Resource](#quota-resource)
-    - [`BackupBucket` Resource](#backupbucket-resource)
-    - [`BackupEntry` Resource](#backupentry-resource)
-    - [`Shoot` Resource](#shoot-resource)
-    - [`Plant` resource](#plant-resource)
-
 ## Summary
 
 In [GEP-1](../0001-gardener-extensibility/README.md) we have proposed how to (re-)design Gardener to allow providers maintaining their provider-specific knowledge out of the core tree.

--- a/geps/0010-container-runtime-extensibility/README.md
+++ b/geps/0010-container-runtime-extensibility/README.md
@@ -1,15 +1,5 @@
 # GEP-0010: Gardener Extensibility to Support Shoot Additional Container Runtimes
 
-## Table of Contents
-
-- [GEP-0010: Gardener Extensibility to Support Shoot Additional Container Runtimes](#gep-0010-gardener-extensibility-to-support-shoot-additional-container-runtimes)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-  - [Proposal](#proposal)
-  - [Design Details](#design-details)
-
 ## Summary
 
 Gardener-managed Kubernetes clusters are sometimes used to run sensitive workloads, which sometimes are comprised of OCI images originating from untrusted sources. Additional use-cases want to leverage economy-of-scale to run workloads for multiple tenants on the same cluster.  In some cases, Gardener users want to use operating systems which do not easily support the Docker engine.

--- a/geps/0014-reversed-cluster-vpn/README.md
+++ b/geps/0014-reversed-cluster-vpn/README.md
@@ -1,11 +1,5 @@
 # GEP-0014: Reversed Cluster VPN
 
-## Table of Contents
-
-* [Motivation](#Motivation)
-* [Proposal](#Proposal)
-* [Alternatives](#Alternatives)
-
 ## Motivation
 
 It is necessary to describe the current VPN solution and outline its shortcomings in order to motivate this proposal.

--- a/geps/0015-bastion-management/README.md
+++ b/geps/0015-bastion-management/README.md
@@ -1,27 +1,11 @@
 # GEP-0015: Bastion Management and SSH Key Pair Rotation
 
-## Table of Contents
-
-- [GEP-0015: Bastion Management and SSH Key Pair Rotation](#gep-0015-bastion-management-and-ssh-key-pair-rotation)
-  - [Table of Contents](#table-of-contents)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Involved Components](#involved-components)
-    - [SSH Flow](#ssh-flow)
-    - [Resource Example](#resource-example)
-  - [SSH Key Pair Rotation](#ssh-key-pair-rotation)
-    - [Rotation Proposal](#rotation-proposal)
-    - [Limitations](#limitations)
-
 ## Motivation
 `gardenctl` (v1) has the functionality to setup `ssh` sessions to the targeted shoot cluster (nodes). To this end, infrastructure resources like VMs, public IPs, firewall rules, etc., have to be created. `gardenctl` will clean up the resources after termination of the `ssh` session (or rather, when the operator is done with her work). However, there were issues in the past where these infrastructure resources were not properly cleaned up afterwards, e.g., due to some error (no retries, either). Hence, the proposal is to have a dedicated controller (for each infrastructure) that manages the infrastructure resources and their cleanup. The current `gardenctl` also reused the `ssh` node credentials for the bastion host. While that's possible, it would be safer to rather use personal or generated `ssh` key pairs to access the bastion host.
 The static shoot-specific `ssh` key pair should be rotated regularly, e.g., once in the maintenance time window. This also means that we cannot create the node VMs anymore with infrastructure public keys as these cannot be revoked or rotated (e.g. in AWS) without terminating the VM itself.
 
 Changes to the `Bastion` resource should only be allowed for controllers on seeds that are responsible for it. This cannot be restricted when using custom resources.
 The proposal, as outlined below, suggests to implement the necessary changes in the gardener core components and to adapt the [SeedAuthorizer](https://github.com/gardener/gardener/issues/1723) to consider `Bastion` resources that the Gardener API Server serves.
-
 
 ### Goals
 - Operators can request and will be granted time-limited `ssh` access to shoot cluster nodes via bastion hosts.

--- a/geps/0016-adminkubeconfig-subresource/README.md
+++ b/geps/0016-adminkubeconfig-subresource/README.md
@@ -1,16 +1,5 @@
 # GEP-0016: Dynamic kubeconfig generation for Shoot clusters
 
-## Table of Contents
-
-- [GEP-0016: Dynamic kubeconfig generation for Shoot clusters](#gep-0016-dynamic-kubeconfig-generation-for-shoot-clusters)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-  - [Alternatives](#alternatives)
-
 ## Summary
 
 This `GEP` introduces a new  `Shoot` subresource called `AdminKubeconfigRequest`, allowing for users to dynamically generate a short-lived `kubeconfig` that can be used to access the `Shoot` cluster as `cluster-admin`.

--- a/geps/0018-shoot-ca-rotation/README.md
+++ b/geps/0018-shoot-ca-rotation/README.md
@@ -1,15 +1,5 @@
 # GEP-0018: Automated Shoot CA Rotation
 
-## Table of Contents
-
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-- [Alternatives](#alternatives)
-- [Open Questions](#open-questions)
-
 ## Summary
 
 This proposal outlines an on-demand, multi-step approach to rotate all certificate authorities (CA) used in a Shoot cluster. This process includes creating new CAs, invalidating the old ones and recreating all certificates signed by the CAs.
@@ -215,7 +205,6 @@ This section presents a different approach to rotate the CAs, which is to _tempo
 - Drop first `DNSRecord`, `Service`, Istio configuration and first `kube-apiserver` deployment
 - Drop `CA0`
 - _Ask the user to optionally restart their `Pod`s since they still contain `CA0` in memory._
-
 
 #### Advantages/Disadvantages Approach Two API Servers
 

--- a/geps/0019-observability-stack-operator-migration/README.md
+++ b/geps/0019-observability-stack-operator-migration/README.md
@@ -1,28 +1,5 @@
 # GEP-0019: Observability Stack - Migrating to the prometheus-operator and fluent-bit-operator
 
-## Table of Contents
-
-- [GEP-0019: Observability Stack - Migrating to the prometheus-operator and fluent-bit-operator](#gep-0019-observability-stack---migrating-to-the-prometheus-operator-and-fluent-bit-operator)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [API](#api)
-    - [Prometheus Operator CRDs](#prometheus-operator-crds)
-    - [Shoot Monitoring](#shoot-monitoring)
-    - [Seed Monitoring](#seed-monitoring)
-    - [BYOMC (Bring your own monitoring configuration)](#byomc-bring-your-own-monitoring-configuration)
-    - [Grafana Sidecar](#grafana-sidecar)
-    - [Fluent-bit Operator CRDs](#fluent-bit-operator-crds)
-    - [Fluent-bit Filters and Parsers](#fluent-bit-filters-and-parsers)
-    - [BYOLC (Bring Your Own Logging Configuration)](#byolc-bring-your-own-logging-configuration)
-    - [Migration](#migration)
-      - [Prometheus Operator](#prometheus-operator)
-      - [Fluent-bit Operator](#fluent-bit-operator)
-  - [Alternatives](#alternatives)
-
 > **Note:** FluentBit Operator is now known as Fluent Operator. The proposal has been left unchanged.
 
 ## Summary

--- a/geps/0020-ha-control-planes/README.md
+++ b/geps/0020-ha-control-planes/README.md
@@ -1,66 +1,5 @@
 # GEP-0020: Highly Available Shoot Control Planes
 
-## Table of Contents
-
-- [GEP-0020: Highly Available Shoot Control Planes](#gep-0020-highly-available-shoot-control-planes)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-  - [High Availability](#high-availability)
-    - [Topologies](#topologies)
-    - [Recommended Number of Nodes and Zones](#recommended-number-of-nodes-and-zones)
-    - [Recommended Number of Replicas](#recommended-number-of-replicas)
-  - [Gardener Shoot API](#gardener-shoot-api)
-    - [Proposed Changes](#proposed-changes)
-  - [Gardener Scheduler](#gardener-scheduler)
-    - [Case #1: HA Shoot with no Seed Assigned](#case-1-ha-shoot-with-no-seed-assigned)
-    - [Case #2: HA Shoot with Assigned Seed and Updated Failure Tolerance](#case-2-ha-shoot-with-assigned-seed-and-updated-failure-tolerance)
-  - [Setting Up a Seed for HA](#setting-up-a-seed-for-ha)
-    - [Hosting an HA Shoot Control Plane with `node` Failure Tolerance](#hosting-an-ha-shoot-control-plane-with-node-failure-tolerance)
-    - [Hosting an HA Shoot Control Plane with `zone` Failure Tolerance](#hosting-an-ha-shoot-control-plane-with-zone-failure-tolerance)
-    - [Compute Seed Usage](#compute-seed-usage)
-  - [Scheduling Control Plane Components](#scheduling-control-plane-components)
-    - [Zone Pinning](#zone-pinning)
-    - [Single-Zone](#single-zone)
-    - [Multi-Zone (#replicas \<= #zones)](#multi-zone-replicas--zones)
-    - [Multi-Zone (#replicas \> #zones)](#multi-zone-replicas--zones-1)
-  - [Disruptions and Zero Downtime Maintenance](#disruptions-and-zero-downtime-maintenance)
-  - [Seed System Components](#seed-system-components)
-  - [Shoot Control Plane Components](#shoot-control-plane-components)
-    - [Kube Apiserver](#kube-apiserver)
-    - [Gardener Resource Manager](#gardener-resource-manager)
-    - [etcd](#etcd)
-      - [Gardener `etcd` Component Changes](#gardener-etcd-component-changes)
-    - [Other Critical Components Having a Single Replica](#other-critical-components-having-a-single-replica)
-  - [Handling Outages](#handling-outages)
-    - [Node Failures](#node-failures)
-      - [Impact of Node Failure](#impact-of-node-failure)
-    - [What is Zone Outage?](#what-is-zone-outage)
-      - [Impact of a Zone Outage](#impact-of-a-zone-outage)
-    - [Identify a Zone Outage](#identify-a-zone-outage)
-    - [Identify Zone Recovery](#identify-zone-recovery)
-    - [Recovery](#recovery)
-      - [Current Recovery Mechanisms](#current-recovery-mechanisms)
-      - [Recovery from Node Failure](#recovery-from-node-failure)
-      - [Recovery from Zone Failure](#recovery-from-zone-failure)
-    - [Option #1: Leverage Existing Recovery Options - `Preferred`](#option-1-leverage-existing-recovery-options---preferred)
-    - [Option #2: Redundancies for All Critical Control Plane Components](#option-2-redundancies-for-all-critical-control-plane-components)
-    - [Option #3: Auto-Rebalance Pods in the Event of an AZ Failure](#option-3-auto-rebalance-pods-in-the-event-of-an-az-failure)
-  - [Cost Implications on Hosting an HA Control Plane](#cost-implications-on-hosting-an-ha-control-plane)
-    - [Compute \& Storage](#compute--storage)
-    - [Network Latency](#network-latency)
-    - [Cross-Zonal Traffic](#cross-zonal-traffic)
-      - [Ingress/Egress Traffic Analysis](#ingressegress-traffic-analysis)
-      - [Optimizing Cost: Topology Aware Hint](#optimizing-cost-topology-aware-hint)
-  - [References](#references)
-  - [Appendix](#appendix)
-    - [etcd Active-Passive Options](#etcd-active-passive-options)
-    - [Topology Spread Constraints Evaluation and Findings](#topology-spread-constraints-evaluation-and-findings)
-    - [Availability Zone Outage Simulation](#availability-zone-outage-simulation)
-    - [Ingress/Egress Traffic Analysis Details](#ingressegress-traffic-analysis-details)
-
 ## Summary
 
 Gardener today only offers highly available control planes for some of its components (like Kubernetes API Server and Gardener Resource Manager) which are deployed with multiple replicas and allow a distribution across nodes. Many of the other critical control plane components including `etcd` are only offered with a single replica, making them susceptible to both node failure as well as zone failure causing downtimes.
@@ -367,7 +306,6 @@ The following shoot control plane components are currently setup with a single r
 
 Additionally [Affinity and anti-affinity](#scheduling-control-plane-components) rules must be configured.
 
-
 ## Handling Outages
 
 ### Node Failures
@@ -638,7 +576,6 @@ Network latency measurements were done focusing on `etcd`. Three different etcd 
   * The `mn-sz` latency is lesser (range of 20-30%) as compared to `mn-mz` when the request is serviced by a follower. However, the difference is usually within the same millisecond.
   * When the number of clients and connections are kept at 1, then irrespective of the payload size it is observed that the latency of the leader is lesser than that of any follower. This is on the expected lines. However, if the number of clients and connections are increased, then the leader seems to have a higher latency as compared to a follower, which could not be explained.
 
-
 **Test findings for GET (Range) requests**
 
 Using an etcd benchmark tool, range requests were generated.
@@ -840,7 +777,6 @@ When the constraints defined above were applied, the following findings were mad
 </details>
 
 > **Note:** Also see the [Known Limitations](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#known-limitations) topic.
-
 
 ### Availability Zone Outage Simulation
 
@@ -1238,7 +1174,6 @@ benchmark put --target-leader  --rate 500 --conns=400 --clients=800 --sequential
     --cert=/var/etcd/ssl/client/client/tls.crt
 ```
 <img src="watch-request-targeting-follower.png"/>
-
 
 _Observations:_
 * etcd intra cluster network traffic remains the same, observed that there is no change in the network traffic pattern.

--- a/geps/0021-ipv6-singlestack-local/README.md
+++ b/geps/0021-ipv6-singlestack-local/README.md
@@ -1,31 +1,5 @@
 # GEP-0021: IPv6 Single-Stack Support in Local Gardener
 
-## Table of Contents
-
-<!-- TOC -->
-- [GEP-0021: IPv6 Single-Stack Support in Local Gardener](#gep-0021-ipv6-single-stack-support-in-local-gardener)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [`Shoot` API](#shoot-api)
-      - [Future Dual-Stack Enhancements](#future-dual-stack-enhancements)
-    - [`Seed` API](#seed-api)
-    - [`Network` API](#network-api)
-    - [`DNSRecord` API](#dnsrecord-api)
-    - [Implementation Overview](#implementation-overview)
-      - [Preparing the Local Setup](#preparing-the-local-setup)
-      - [DNS Records](#dns-records)
-      - [Network Policies](#network-policies)
-      - [Shoot Worker Node Kernel Configuration](#shoot-worker-node-kernel-configuration)
-      - [Docker Hub Images](#docker-hub-images)
-      - [E2E Tests](#e2e-tests)
-      - [Networking Extensions](#networking-extensions)
-  - [Alternatives Considered](#alternatives-considered)
-<!-- TOC -->
-
 ## Summary
 
 Today, all shoot clusters provisioned by Gardener use IPv4 single-stack networking.

--- a/geps/0022-improved-shootstate-usage/README.md
+++ b/geps/0022-improved-shootstate-usage/README.md
@@ -1,21 +1,5 @@
 # GEP-0022: Improved Usage of the `ShootState` API
 
-## Table of Contents
-
-<!-- TOC -->
-- [GEP-0022: Improved Usage of the `ShootState` API](#gep-0022-improved-usage-of-the-shootstate-api)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-  - [Alternatives](#alternatives)
-  - [Future Improvements](#future-improvements)
-    - [Eliminating the `Worker` State Reconciler](#eliminating-the-worker-state-reconciler)
-    - [Compressing the `ShootState` Data](#compressing-the-shootstate-data)
-<!-- TOC -->
-
 ## Summary
 
 For each `Shoot` resource, `gardenlet` creates a corresponding `ShootState` resource which has the same lifecycle as the `Shoot`.

--- a/geps/0023-autoscaling-kube-apiserver-via-independent-hpa-and-vpa/README.md
+++ b/geps/0023-autoscaling-kube-apiserver-via-independent-hpa-and-vpa/README.md
@@ -6,31 +6,6 @@ The GEP is replaced by an autoscaling solution for Kubernetes API server based o
 
 ---
 
-## Table of Contents
-- [GEP-0023: Autoscaling Shoot kube-apiserver via Independently Driven HPA and VPA](#gep-0023-autoscaling-shoot-kube-apiserver-via-independently-driven-hpa-and-vpa)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Existing Solution](#existing-solution)
-    - [Deficiencies of the Existing Solution](#deficiencies-of-the-existing-solution)
-    - [Other Benefits to Replacing the Existing Solution](#other-benefits-to-replacing-the-existing-solution)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Rationale](#rationale)
-    - [Design Outline](#design-outline)
-    - [Element: Gardener Custom Metrics Provider Component](#element-gardener-custom-metrics-provider-component)
-      - [High availability operation](#high-availability-operation)
-    - [Element: New Custom Pod Metric for ShootKapis](#element-new-custom-pod-metric-for-shootkapis)
-    - [Element: HPA](#element-hpa)
-    - [Element: VPA](#element-vpa)
-    - [Transition Strategy](#transition-strategy)
-  - [Discussion and Limitations](#discussion-and-limitations)
-      - [Gardener-custom metrics precludes the use of other sources of custom metrics](#gardener-custom-metrics-precludes-the-use-of-other-sources-of-custom-metrics)
-      - [Observed fluctuations in actual compute efficiency affecting ShootKapi workloads](#observed-fluctuations-in-actual-compute-efficiency-affecting-shootkapi-workloads)
-  - [Alternatives](#alternatives)
-  - [References](#references)
-
 ## Summary
 When it comes to autoscaling shoot control plane `kube-apiserver` instances (ShootKapi hereafter), Gardener needs
 both stability and efficiency (accurate scaling). The existing approach of fusing HPA and VPA into the 2-dimensional

--- a/geps/0024-shoot-oidc-issuer/README.md
+++ b/geps/0024-shoot-oidc-issuer/README.md
@@ -1,19 +1,5 @@
 # GEP-0024: Shoot OIDC Issuer
 
-## Table of Contents
-
-- [GEP-0024: Shoot OIDC Issuer](#gep-0024-shoot-oidc-issuer)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Static validation](#static-validation)
-    - [Gardenlet](#gardenlet)
-    - [Metadata Server](#metadata-server)
-  - [Clarifications](#clarifications)
-
 ## Summary
 
 Kubernetes clusters can act as an OIDC compatible provider in a sense that they serve OIDC discovery documents. These documents if publicly accessible can be used by other systems to establish trust to such clusters by fetching the public key part of the key that is used to sign service account tokens. The public keys can be then used by external systems to verify that a service account token is issued by a particular cluster and then grant access to the bearer of that token.

--- a/geps/0025-namespaced-cloudprofiles/README.md
+++ b/geps/0025-namespaced-cloudprofiles/README.md
@@ -1,31 +1,5 @@
 # GEP-0025: Namespaced Cloud Profiles
 
-## Table of Contents
-
-- [GEP-0025: Namespaced Cloud Profiles](#gep-0025-namespaced-cloud-profiles)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Context](#context)
-    - [Current State](#current-state)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Approach](#approach)
-    - [Manifest](#manifest)
-    - [Rendering](#rendering)
-    - [Custom RBAC verb](#custom-rbac-verb)
-    - [Preventing deletion of certain fields in parent `CloudProfile`](#preventing-deletion-of-certain-fields-in-parent-cloudprofile)
-    - [Adjusting `Shoot`s `cloudProfileName` field](#adjusting-shoots-cloudprofilename-field)
-    - [Migration path](#migration-path)
-  - [Outlook](#outlook)
-    - [Cross-project sharing](#cross-project-sharing)
-    - [Multi-Level inheritance](#multi-level-inheritance)
-    - [`NamespacedCloudProfile`s replacing regular `CloudProfile`s](#namespacedcloudprofiles-replacing-regular-cloudprofiles)
-  - [Alternatives](#alternatives)
-    - [Arbitrary Value Fields](#arbitrary-value-fields)
-    - [Namespaced Cloud Profiles by Selection](#namespaced-cloud-profiles-by-selection)
-
 ## Summary
 
 [CloudProfiles](https://github.com/gardener/gardener/blob/master/docs/concepts/apiserver.md#cloudprofiles) are non-namespaced objects that are managed centrally by Gardener operators. They usually contain not only global configuration, but options that are relevant to certain projects only (e.g. special machine types). This increases the operation burden for operators and clutters `CloudProfile` objects. On the other hand, users are blocked until the requested special configuration is rolled out to the desired landscapes.

--- a/geps/0026-workload-identity/README.md
+++ b/geps/0026-workload-identity/README.md
@@ -1,25 +1,5 @@
 # GEP-0026: Workload Identity - Trust Based Authentication
 
-## Table of Contents
-
-- [GEP-0026: Workload Identity - Trust Based Authentication](#gep-0026-workload-identity---trust-based-authentication)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [API Changes](#api-changes)
-      - [Shoot API Related Changes](#shoot-api-related-changes)
-      - [Seed API Related Changes](#seed-api-related-changes)
-    - [Gardener as OIDC Token Issuer](#gardener-as-oidc-token-issuer)
-    - [Distribution of Workload Identity Tokens](#distribution-of-workload-identity-tokens)
-    - [Use cases](#use-cases)
-  - [Alternatives](#alternatives)
-    - [SPIFFE/SPIRE](#spiffespire)
-    - [Kubernetes Service Account Tokens From Garden Cluster](#kubernetes-service-account-tokens-from-garden-cluster)
-    - [Kubernetes Service Account Tokens From Seed Cluster](#kubernetes-service-account-tokens-from-seed-cluster)
-
 ## Summary
 
 Gardener issues and distributes JSON Web Tokens that can be used for

--- a/geps/0027-cloudprofile-bastion-section/README.md
+++ b/geps/0027-cloudprofile-bastion-section/README.md
@@ -1,14 +1,5 @@
 # GEP-0027: Add Optional Bastion Section to CloudProfile
 
-## Table of Contents
-
-- [Summary](#summary)
-- [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Prerequisites](#prerequisites)
-- [Proposal](#proposal)
-- [Alternatives](#alternatives)
-
 ## Summary
 
 Our plan is to extend the gardener core [CloudProfile](https://github.com/gardener/gardener/blob/de64bb6ad2ff2e1a3155b44e0e4a1e565b3206b3/docs/api-reference/core.md#cloudprofile) with a new bastion section that will allow us to create a bastion instance with a specific machine image and machine type that will be referenced in that new section.

--- a/geps/0028-self-hosted-shoot-clusters/README.md
+++ b/geps/0028-self-hosted-shoot-clusters/README.md
@@ -1,47 +1,5 @@
 # GEP-0028: Self-Hosted Shoot Clusters
 
-## Table of Contents
-
-- [GEP-0028: Self-Hosted Shoot Clusters](#gep-0028-self-hosted-shoot-clusters)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Prerequisites](#prerequisites)
-    - [Commands](#commands)
-      - [`gardenadm discover`](#gardenadm-discover)
-      - [`gardenadm init`](#gardenadm-init)
-        - [Problems \& Solutions](#problems--solutions)
-          - [Faking a Kubernetes API](#faking-a-kubernetes-api)
-          - [Host Network vs. Pod Network](#host-network-vs-pod-network)
-          - [Dealing with Webhooks for Control Plane Components](#dealing-with-webhooks-for-control-plane-components)
-          - [`etcd` Management via `etcd-druid`](#etcd-management-via-etcd-druid)
-      - [`gardenadm token`](#gardenadm-token)
-      - [`gardenadm join`](#gardenadm-join)
-      - [`gardenadm connect`](#gardenadm-connect)
-      - [`gardenadm version`](#gardenadm-version)
-    - [`Shoot` API](#shoot-api)
-    - [Scenarios](#scenarios)
-      - [Unmanaged Infrastructure](#unmanaged-infrastructure)
-      - [Managed Infrastructure](#managed-infrastructure)
-        - [`gardenadm bootstrap`](#gardenadm-bootstrap)
-    - [Disaster Recovery](#disaster-recovery)
-      - [Single-Node Failure](#single-node-failure)
-      - [Multi-Node Failure](#multi-node-failure)
-      - [Data Center Failure](#data-center-failure)
-  - [Future Work](#future-work)
-    - [Self-Hosted Shoot Clusters for End-Users](#self-hosted-shoot-clusters-for-end-users)
-    - [Network Connectivity to Garden Cluster](#network-connectivity-to-garden-cluster)
-    - [Changes to Shoot Components](#changes-to-shoot-components)
-    - [Air-Gapped Gardener Landscapes](#air-gapped-gardener-landscapes)
-    - [Scaling the Control Plane of Self-Hosted Shoot Clusters](#scaling-the-control-plane-of-self-hosted-shoot-clusters)
-  - [Alternatives](#alternatives)
-    - [Using Existing Tools](#using-existing-tools)
-    - [Using Existing Services](#using-existing-services)
-    - [Using Existing Gardener](#using-existing-gardener)
-
 ## Summary
 
 Gardener ships with functionality that would allow the creation of "self-hosted" shoot clusters.

--- a/geps/0030-apiserver-proxy/README.md
+++ b/geps/0030-apiserver-proxy/README.md
@@ -1,22 +1,5 @@
 # GEP-0030: Rework API Server Proxy to Drop Proxy Protocol
 
-## Table of Contents
-
-- [GEP-0030: Rework API Server Proxy to Drop Proxy Protocol](#gep-0030-rework-api-server-proxy-to-drop-proxy-protocol)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Reconfiguring the API Server Proxy](#reconfiguring-the-api-server-proxy)
-    - [Reconfiguring the Istio Ingress Gateway](#reconfiguring-the-istio-ingress-gateway)
-    - [Unifying the HTTP Proxy Infrastructure](#unifying-the-http-proxy-infrastructure)
-    - [Rollout Plan](#rollout-plan)
-  - [Alternatives](#alternatives)
-  - [Appendix](#appendix)
-    - [Visualization of the Architecture](#visualization-of-the-architecture)
-
 ## Summary
 [](../0008-shoot-apiserver-via-sni/README.md)
 This proposal reworks the API server proxy (originally introduced in [GEP-08](../0008-shoot-apiserver-via-sni/README.md)) to use [HTTP CONNECT requests](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6) (i.e., HTTP proxy) instead of the [proxy protocol](https://www.haproxy.org/download/3.2/doc/proxy-protocol.txt) for connecting in-cluster clients on the shoot side to the corresponding API server on the seed side.

--- a/geps/0031-inplace-node-updates/README.md
+++ b/geps/0031-inplace-node-updates/README.md
@@ -1,42 +1,5 @@
 # GEP-0031: In-Place Node Updates of Shoot Clusters
 
-## Table of Contents
-
-- [GEP-0031: In-Place Node Updates of Shoot Clusters](#gep-0031-in-place-node-updates-of-shoot-clusters)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Approach](#approach)
-    - [Prerequisites](#prerequisites)
-    - [Update Strategies](#update-strategies)
-      - [`AutoInPlaceUpdate` strategy](#autoinplaceupdate-strategy)
-      - [`ManualInPlaceUpdate` strategy](#manualinplaceupdate-strategy)
-    - [Gardener](#gardener)
-      - [`CloudProfile` API](#cloudprofile-api)
-      - [`Shoot` API](#shoot-api)
-      - [`Worker` API](#worker-api)
-      - [`OperatingSystemConfig` API](#operatingsystemconfig-api)
-      - [Gardener Node Agent](#gardener-node-agent)
-    - [Machine Controller Manager](#machine-controller-manager)
-      - [`MachineDeployment` API](#machinedeployment-api)
-    - [Dependency Watchdog](#dependency-watchdog)
-    - [Extensions](#extensions)
-      - [OS extensions](#os-extensions)
-    - [Worker pool hash calculations](#worker-pool-hash-calculations)
-    - [Failures and Recovery Strategy](#failures-and-recovery-strategy)
-      - [Types of Failures During Update](#types-of-failures-during-update)
-        - [Drain Timeout/Failure](#drain-timeoutfailure)
-        - [Kubernetes Update Failures](#kubernetes-update-failures)
-        - [OS Update Failures](#os-update-failures)
-      - [Roles in Failure Handling](#roles-in-failure-handling)
-  - [Future Work](#future-work)
-  - [Alternatives](#alternatives)
-    - [Using Only Gardener Node Agent](#using-only-gardener-node-agent)
-    - [Using the same name for `MachineClass`](#using-the-same-name-for-machineclass)
-
 ## Summary
 
 Gardener should support new update strategies for nodes that do not require the deletion and recreation of the nodes. These strategies aim to minimize the overhead traditionally associated with node replacement and offer an alternative approach to updates, which is particularly important for physical machines or bare-metal nodes.

--- a/geps/0032-version-classification-lifecycle/README.md
+++ b/geps/0032-version-classification-lifecycle/README.md
@@ -1,21 +1,5 @@
 # GEP-0032: Cloud Profile Version Classification Lifecycles
 
-## Table of Contents
-
-- [GEP-0032: Cloud Profile Version Classification Lifecycles](#gep-0032-cloud-profile-version-classification-lifecycles)
-  - [Table of Contents](#table-of-contents)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Backwards Compatibility](#backwards-compatibility)
-    - [Compatibility with Namespaced Cloud Profiles](#compatibility-with-namespaced-cloud-profiles)
-  - [Considered Alternatives](#considered-alternatives)
-    - [Consequent Continuation of Current Approach](#consequent-continuation-of-current-approach)
-    - [Introduction of a Lifecycle Map](#introduction-of-a-lifecycle-map)
-    - [Status vs. Classification Field Patching](#status-vs-classification-field-patching)
-    - [Implementation Without the Status Field](#implementation-without-the-status-field)
-
 ## Motivation
 
 At the current stage of implementation, Gardener administrators may classify Kubernetes versions and machine image versions using the `CloudProfile` spec.
@@ -174,7 +158,6 @@ Of course the new version classification lifecycles must be compatible with `Nam
 
 In the previous implementation a version's `classification` could not be changed, while changing the `expirationDate` is allowed. We try to retain this intention.
 Hence changing the `startTime` of a stage is possible, but introducing new lifecycle stages isn't.
-
 
 Given the `CloudProfile` from above, the following `NamespacedCloudProfile` is valid:
 

--- a/geps/0033-machine-image-capabilities/README.md
+++ b/geps/0033-machine-image-capabilities/README.md
@@ -1,14 +1,5 @@
 # GEP-0033: Machine Image Capabilities
 
-## Table of Contents
-
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-- [Alternatives](#alternatives)
-
 ## Summary
 
 This GEP proposes the introduction of capabilities for machineType and machineImage in the Gardener CloudProfile to ensure only shoots with a matching set of capabilities on machine type and image will be admitted by Gardener.
@@ -59,7 +50,6 @@ The user has to know about that and select the proper machine image manually AND
 For each infrastructure provider Gardener operators must provide a CloudProfile.
 It describes the catalog of machines, images and other resources of the infrastructure provider.
 Only machines and images that are described in the CloudProfile can be used to create a shoot.
-
 
 There are three places in the CloudProfile where metadata is required:
 
@@ -351,7 +341,6 @@ The following implications are to be considered in regards to `NamespacedCloudPr
 * For custom machine image versions, the `capabilities` need to be defined in the `NamespacedCloudProfile`, as they would be in the `CloudProfile` (as well as for the `providerConfig`).
    
 * This has also implications on later-added equal machine image versions to the parent `CloudProfile`: On conflicting definition, the machine image version of the `NamespacedCloudProfile` will be rendered in the resulting status (see [this PR](https://github.com/gardener/gardener/pull/11093) for reference).
-
 
 ### Migration Strategy
 

--- a/geps/0034-observability2.0-opentelemetry/README.md
+++ b/geps/0034-observability2.0-opentelemetry/README.md
@@ -1,16 +1,5 @@
 # GEP-0034: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes
 
-## Table of Contents
-
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-- [Alternatives](#alternatives)
-
----
-
 ## Summary
 
 This proposal introduces the OpenTelemetry Operator and deploys OpenTelemetry Collectors within the shoot control plane namespaces of Gardener-managed clusters. Building on the foundation laid by [GEP-19](../0019-observability-stack-operator-migration) (migration to Prometheus and Fluent-bit operators) and the [Observability 2.0](./observability-2.0.md) vision, this GEP advances Gardener's observability stack by adopting OpenTelemetry standards. The initiative aims to layout the foundation for building a more cohesive and interoperable observability framework. This GEP takes the first step by introducing OpenTelemetry for logging, aligning with the [Observability 2.0](./observability-2.0.md) vision, with future enhancements planned to include metrics and optionally traces.

--- a/geps/0035-observability2.0-victorialogs/README.md
+++ b/geps/0035-observability2.0-victorialogs/README.md
@@ -1,15 +1,5 @@
 # GEP-0035: Migrating from Vali to VictoriaLogs
 
-## Table of Contents
-
-- [Terminology](#terminology)
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-- [Alternatives](#alternatives)
-
 ## Terminology
 
 Since this document relies on work that has already been done in [GEP-34](../0034-observability2.0-opentelemetry/README.md), the same terminology applies here as well:

--- a/geps/0036-self-hosted-shoot-exposure/README.md
+++ b/geps/0036-self-hosted-shoot-exposure/README.md
@@ -1,23 +1,5 @@
 # GEP-0036: Self-Hosted Shoot Exposure
 
-## Table of Contents
-
-- [GEP-0036: Self-Hosted Shoot Exposure](#gep-0036-self-hosted-shoot-exposure)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [`Shoot` API Changes](#shoot-api-changes)
-    - [`SelfHostedShootExposure` Extension Resource](#selfhostedshootexposure-extension-resource)
-      - [Extension Controller Interface](#extension-controller-interface)
-      - [Examples of Possible Extension Implementations](#examples-of-possible-extension-implementations)
-    - [DNS-Based Control Plane Exposure](#dns-based-control-plane-exposure)
-    - [gardenlet Controller for Updating Control Plane Endpoints](#gardenlet-controller-for-updating-control-plane-endpoints)
-  - [Alternatives](#alternatives)
-    - [Service of Type `LoadBalancer`](#service-of-type-loadbalancer)
-
 ## Summary
 
 This proposal introduces a standardized mechanism for exposing the API server of self-hosted shoot clusters with managed infrastructure (see [GEP-28](../0028-self-hosted-shoot-clusters/README.md#managed-infrastructure)), e.g., using a load balancer of the underlying infrastructure provider or other strategies.

--- a/geps/0037-scaling-advisor/README.md
+++ b/geps/0037-scaling-advisor/README.md
@@ -1,31 +1,5 @@
 # GEP-0037: Scaling Advisor
 
-## Table of Contents
-
-- [GEP-0037: Scaling Advisor](#gep-0037-scaling-advisor)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Issues \& Challenges](#issues--challenges)
-      - [Multiple Overlapping Actors:](#multiple-overlapping-actors)
-      - [CA inherent design flaws](#ca-inherent-design-flaws)
-        - [Impedence mismatch between CA and kube-scheduler](#impedence-mismatch-between-ca-and-kube-scheduler)
-        - [Inefficient scaling of NodeGroup(s)](#inefficient-scaling-of-nodegroups)
-      - [Scalability challenges](#scalability-challenges)
-      - [Maintenance challenges](#maintenance-challenges)
-        - [Diagnostic challenges](#diagnostic-challenges)
-  - [Way forward](#way-forward)
-    - [Alternatives evaluated](#alternatives-evaluated)
-    - [How we addressed CA challenges?](#how-we-addressed-ca-challenges)
-      - [Single actor responsibility](#single-actor-responsibility)
-      - [Alleviating CA inherent design flaws](#alleviating-ca-inherent-design-flaws)
-      - [Scalability](#scalability)
-    - [Proof of concept validation](#proof-of-concept-validation)
-    - [Envisaged value differentiators](#envisaged-value-differentiators)
-    - [Risk Mitigation](#risk-mitigation)
-    - [Non Goal](#non-goal)
-  - [Appendix](#appendix)
-
 ## Summary
 
 Gardener uses a [fork](https://github.com/gardener/autoscaler/tree/machine-controller-manager-provider/cluster-autoscaler) of upstream [Cluster-Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) (a.k.a. CA) to scale out/in Shoot clusters and it uses [machine-controller-manager](https://github.com/gardener/machine-controller-manager) (a.k.a. MCM) to manage the lifecycle of machines. In the CA fork, we have an in-tree implementation of [CloudProvider](https://github.com/gardener/autoscaler/blob/45e190f4bd7890e0029bef8eb9affa0946f135d5/cluster-autoscaler/cloudprovider/cloud_provider.go#L106) interface for [MCM](https://github.com/gardener/autoscaler/blob/45e190f4bd7890e0029bef8eb9affa0946f135d5/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go#L69). Over several years of using these components together, we have encountered numerous challenges and shortcomings when working with CA.
@@ -97,12 +71,10 @@ Gardener provides capabilities to scale-in and scale-out a kubernetes cluster vi
   * To minimise the 2-actor problems between CA and MCM, core CA code has been adapted/changed/commented. With every rebase care needs to be taken to ensure that modified code continues to work.
   * The overall size of the CA repository is over 200Mb which includes the code from multiple cloud provider implementations that is not consumed in Gardener. As a consequence local setup and development is resource heavy and slow.
 
-
 ##### Diagnostic challenges
 
 * Pod triggered scaled up events emitted by the CA are inaccurate since all the pods that were involved in the scale-out evaluation were logged as part of this triggered-scale-up-event. This set of pods is not neccessarily the set of pods that caused the actual scale up. This makes diagnostics trickier and developers needs to be trained to ignore these logs and only look at the final scale-out plan.
 * CA does not emit logs at the right log-level for critical failure in scaling-out NodeGroups. This forces the operators to change the log level to DEBUG to get this information which in turn results in an overload of logs.
-
 
 ## Way forward
 
@@ -121,7 +93,6 @@ Currently there are only [two cluster autoscaling implementations](https://kuber
 A proof-of-concept [Scaling Advisor](https://github.tools.sap/kubernetes/gardener-scaling-recommender) was envisaged which has single responsibility to provide scaling advice by leveraging the kubernetes kube-scheduler on the current cluster state.
 
 ![Scaling Advisor POC Flow](./poc-flow.png)
-
 
 #### Single actor responsibility
 
@@ -168,7 +139,6 @@ Anectodally we observed that scaling advisor POC was faster than CA in computing
 
 * scaling-advisor is independent of the Cluster API. Any VM lifecycle management component can leverage this as a library.
 * scaling-advisor will not revise the Gardener worker pool concept.
-
 
 ## Appendix
 

--- a/geps/0038-autoscaling-persistentvolumeclaims/README.md
+++ b/geps/0038-autoscaling-persistentvolumeclaims/README.md
@@ -1,63 +1,5 @@
 # GEP-0038: Autoscaling PersistentVolumeClaims
 
-## Table of Contents
-
-- [GEP-0038: Autoscaling PersistentVolumeClaims](#gep-0038-autoscaling-persistentvolumeclaims)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Problem Statement](#problem-statement)
-    - [Why this matters](#why-this-matters)
-    - [Who Benefits](#who-benefits)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Core Concept](#core-concept)
-    - [Example API Design](#example-api-design)
-    - [Key Features](#key-features)
-      - [Automatic PVC Discovery](#automatic-pvc-discovery)
-      - [Volume-Specific Policies](#volume-specific-policies)
-      - [Observability and Monitoring](#observability-and-monitoring)
-    - [Scaling Algorithm](#scaling-algorithm)
-      - [Scale-Up Decision Logic](#scale-up-decision-logic)
-      - [Handling Scale-Up Failures](#handling-scale-up-failures)
-      - [Why Downscaling is a Non-Goal](#why-downscaling-is-a-non-goal)
-      - [PVC Admission Webhook Considerations](#pvc-admission-webhook-considerations)
-    - [Architecture Overview](#architecture-overview)
-    - [Gardener Integration](#gardener-integration)
-      - [Integration Into Seed Clusters](#integration-into-seed-clusters)
-      - [Integration Into Gardener Runtime Clusters](#integration-into-gardener-runtime-clusters)
-      - [Support for Shoot Clusters](#support-for-shoot-clusters)
-  - [Impact and Alternatives](#impact-and-alternatives)
-    - [Risks, Downsides and Trade-offs](#risks-downsides-and-trade-offs)
-      - [Metrics used for volume stats are still ALPHA](#metrics-used-for-volume-stats-are-still-alpha)
-      - [Metrics Sources](#metrics-sources)
-      - [Latency](#latency)
-      - [Cloud Provider Limitations](#cloud-provider-limitations)
-      - [Dependency on `csi-resizer`](#dependency-on-csi-resizer)
-    - [Scaling Algorithm and API Alternatives](#scaling-algorithm-and-api-alternatives)
-      - [VPA's Historical Approach](#vpas-historical-approach)
-      - [Trend-Based Algorithm](#trend-based-algorithm)
-      - [Gliding Average Algorithm](#gliding-average-algorithm)
-      - [Gliding Maximum Algorithm](#gliding-maximum-algorithm)
-    - [Alternative 3rd Party PVC Autoscalers](#alternative-3rd-party-pvc-autoscalers)
-      - [Alternative: topolvm/pvc-autoscaler](#alternative-topolvmpvc-autoscaler)
-      - [Alternative: lorenzophys/pvc-autoscaler](#alternative-lorenzophyspvc-autoscaler)
-      - [Alternative: DevOps-Nirvana/Kubernetes-Volume-Autoscaler](#alternative-devops-nirvanakubernetes-volume-autoscaler)
-  - [Decision Request](#decision-request)
-    - [Proposed Implementation Timeline](#proposed-implementation-timeline)
-      - [Phase 1 (Core Implementation)](#phase-1-core-implementation)
-      - [Phase 2 (Gardener Integration)](#phase-2-gardener-integration)
-      - [Phase 3 (Future Enhancement)](#phase-3-future-enhancement)
-      - [Phase 4 (If required by stakeholders)](#phase-4-if-required-by-stakeholders)
-    - [Next Steps](#next-steps)
-  - [Appendix](#appendix)
-    - [How PVCs are managed by workload controllers](#how-pvcs-are-managed-by-workload-controllers)
-      - [StatefulSets](#statefulsets)
-      - [Prometheus](#prometheus)
-      - [VLSingle](#vlsingle)
-    - [Supporting materials (linked or embedded)](#supporting-materials-linked-or-embedded)
-
 ## Summary
 
 Gardener currently uses a one-size-fits-all strategy for the volumes of its observability workloads which can be problematic due to both over-provisioning (generating extra costs) and under-provisioning (missing observability signals).
@@ -253,8 +195,6 @@ When the Pod starts and re-mounts the volume, the file system is automatically r
 
 The current plan is to implement these steps as part of a separate controller in the `pvc-autoscaler` which will be responsible for evicting affected Pods and removing the scheduling gate once they are ready to be scheduled.
 The webhook, which adds scheduling gates to Pods, will run inside the `pvc-autoscaler` so that all of the aspects are handled by one component.
-
-
 
 **Insufficient cloud provider resources:**
 When a resize fails due to lack of resources on the cloud provider side, the `pvc-autoscaler` can leverage the [Recovery From Volume Expansion Failure][10] feature available in Kubernetes 1.34+.

--- a/geps/0039-live-control-plane-migration/README.md
+++ b/geps/0039-live-control-plane-migration/README.md
@@ -1,40 +1,5 @@
 # GEP-0039: Live Control Plane Migration
 
-## Table of Contents
-
-- [GEP-0039: Live Control Plane Migration](#gep-0039-live-control-plane-migration)
-  - [Table of Contents](#table-of-contents)
-  - [Terminology](#terminology)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Approach](#approach)
-    - [Prerequisites](#prerequisites)
-    - [Gardener](#gardener)
-      - [Shoot API](#shoot-api)
-      - [etcd Peer Communication](#etcd-peer-communication)
-      - [Components with Shoot webhooks and Controllers reconciling shoot objects](#components-with-shoot-webhooks-and-controllers-reconciling-shoot-objects)
-      - [Live Migration Flow](#live-migration-flow)
-    - [etcd-druid](#etcd-druid)
-      - [Five member etcd cluster](#five-member-etcd-cluster)
-      - [Member removal from the cluster](#member-removal-from-the-cluster)
-      - [Decoupling Member Names from Pod Names](#decoupling-member-names-from-pod-names)
-    - [VPN](#vpn)
-    - [Failures and Recovery Strategy](#failures-and-recovery-strategy)
-      - [**ETCD Quorum loss**](#etcd-quorum-loss)
-        - [The destination members are unable to join](#the-destination-members-are-unable-to-join)
-        - [Quorum is lost at any other stage](#quorum-is-lost-at-any-other-stage)
-      - [Kube API Server is unhealthy](#kube-api-server-is-unhealthy)
-        - [ETCD is unhealthy](#etcd-is-unhealthy)
-        - [ETCD is healthy](#etcd-is-healthy)
-    - [Future Scope](#future-scope)
-  - [Alternatives](#alternatives)
-    - [etcd Mirror Maker](#etcd-mirror-maker)
-    - [etcd Gateway](#etcd-gateway)
-    - [3-Member etcd Cluster](#3-member-etcd-cluster)
-
 ## Terminology
 
 **Source `Seed`** is the seed that currently hosts the control plane of the shoot cluster.

--- a/geps/0049-gardener-landscape-kit/README.md
+++ b/geps/0049-gardener-landscape-kit/README.md
@@ -1,25 +1,5 @@
 # GEP-0049: Gardener Landscape Kit
 
-## Table of Contents
-
-- [GEP-0049: Gardener Landscape Kit](#gep-0049-gardener-landscape-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
-    - [Risks and Mitigations](#risks-and-mitigations)
-  - [Design Details](#design-details)
-    - [Repositories](#repositories)
-    - [Components](#components)
-    - [Versions and OCI References](#versions-and-oci-references)
-    - [Configuration API](#configuration-api)
-  - [Drawbacks](#drawbacks)
-  - [Alternatives](#alternatives)
-  - [Appendix](#appendix)
-
 ## Summary
 
 The Gardener Landscape Kit (GLK, or `gardener-landscape-kit`) aims to deliver tools and best practices for managing Gardener, from small-size to large-scale landscapes.

--- a/geps/0057-replace-nginx-ingress-shoot-addon-with-traefik-extension/README.md
+++ b/geps/0057-replace-nginx-ingress-shoot-addon-with-traefik-extension/README.md
@@ -1,35 +1,5 @@
 # GEP-57: Replace Nginx Ingress Shoot Addon with Traefik Extension
 
-## Table of Contents
-
-- [GEP-57: Replace Nginx Ingress Shoot Addon with Traefik Extension](#gep-57-replace-nginx-ingress-shoot-addon-with-traefik-extension)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Notes/Constraints/Caveats](#notesconstraintscaveats)
-    - [Risks and Mitigations](#risks-and-mitigations)
-  - [Design Details](#design-details)
-    - [Extension Registration](#extension-registration)
-    - [API](#api)
-    - [Ingress Provider Modes](#ingress-provider-modes)
-    - [Admission Webhook](#admission-webhook)
-    - [Lifecycle Management](#lifecycle-management)
-    - [Scope Restriction: Evaluation Shoots Only](#scope-restriction-evaluation-shoots-only)
-  - [Future Enhancements](#future-enhancements)
-    - [Feature Gate Configuration](#feature-gate-configuration)
-    - [Traefik Version Handling](#traefik-version-handling)
-  - [Drawbacks](#drawbacks)
-  - [Alternatives](#alternatives)
-    - [1. Continue Shipping Ingress NGINX](#1-continue-shipping-ingress-nginx)
-    - [2. Use a Cloud-Provider-Specific Ingress Controller](#2-use-a-cloud-provider-specific-ingress-controller)
-    - [3. Adopt Kubernetes Gateway API Exclusively](#3-adopt-kubernetes-gateway-api-exclusively)
-    - [4. Ingress NGINX Fork / Community Takeover](#4-ingress-nginx-fork--community-takeover)
-    - [5. Different Ingress Controller (e.g. Contour, Emissary, HAProxy Ingress)](#5-different-ingress-controller-eg-contour-emissary-haproxy-ingress)
-
-
 ## Summary
 
 [Ingress NGINX](https://github.com/kubernetes/ingress-nginx/) — the standard
@@ -46,7 +16,6 @@ shoot clusters.  The extension follows the standard Gardener extension
 contract (controller registration, `ManagedResource`-based deployment,
 admission webhooks) and provides a migration-friendly path for workloads that
 previously relied on NGINX-specific `Ingress` annotations.
-
 
 ## Motivation
 
@@ -110,7 +79,6 @@ Key problems this GEP addresses:
    policies, or advanced traffic shaping beyond what Traefik exposes out
    of the box through its standard Kubernetes Ingress and IngressRoute CRDs.
 
-
 ## Proposal
 
 Introduce `gardener-extension-shoot-traefik` as a new extension in the
@@ -168,7 +136,6 @@ The extension type identifier is **`shoot-traefik`** (referenced in
 | CRD conflicts if Traefik is pre-installed in the shoot | Low | High | CRDs are part of the shoot `ManagedResource` and are applied by the Gardener resource-manager using server-side apply, so pre-existing CRDs (e.g. from a user-managed Traefik installation) are updated idempotently without field-ownership conflicts. |
 | Extension limited to evaluation shoots | High | Medium | The evaluation-purpose restriction is intentional.  The extension is currently scoped to `purpose: evaluation` shoots only. |
 | Legacy addon and new extension run simultaneously | Low | Medium | Both the old nginx addon and the Traefik extension register separate IngressClasses (`nginx` / `traefik`), so they can coexist without routing conflicts during a migration window.  Documentation will advise against using both long-term. |
-
 
 ## Design Details
 
@@ -345,7 +312,6 @@ This allows:
 The restriction is enforced exclusively in the admission webhook and can be
 removed or made configurable by operators without any API change.
 
-
 ## Future Enhancements
 
 ### Feature Gate Configuration
@@ -372,7 +338,6 @@ lifecycle classifications (aligned with
 [GEP-32](../0032-version-classification-lifecycle/README.md)) and letting
 shoot owners pin a specific version.
 
-
 ## Drawbacks
 
 * **Incomplete annotation parity with NGINX**: The `KubernetesIngressNGINX`
@@ -384,7 +349,6 @@ shoot owners pin a specific version.
 * **Traefik CRD proliferation**: Even users who only use standard Kubernetes
   `Ingress` objects will have Traefik-specific CRDs installed in their shoot.
   This adds a small amount of API surface that may be unexpected.
-
 
 ## Alternatives
 

--- a/geps/NNNN-gep-template/README.md
+++ b/geps/NNNN-gep-template/README.md
@@ -1,20 +1,5 @@
 # GEP-NNNN: Your short, descriptive title
 
-## Table of Contents
-
-- [GEP-NNNN: Your short, descriptive title](#gep-nnnn-your-short-descriptive-title)
-  - [Table of Contents](#table-of-contents)
-  - [Summary](#summary)
-  - [Motivation](#motivation)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Proposal](#proposal)
-    - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
-    - [Risks and Mitigations](#risks-and-mitigations)
-  - [Design Details](#design-details)
-  - [Drawbacks](#drawbacks)
-  - [Alternatives](#alternatives)
-
 ## Summary
 
 <!--


### PR DESCRIPTION
- How to categorize this PR:
/area documentation
/kind cleanup

- One-line PR description:
Remove the manually maintained Table of Contents sections from the GEP template and all existing GEP README files.

- Issue link:
N/A

- Other comments:
The Table of Contents tends to get outdated, has not been added to all proposals, and GitHub already displays a nice content outline when viewing GEPs.