### PR TITLE
Replace vlerenc with vpnachev in TSC members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,4 +5,4 @@ aliases:
   - rfranzke
   - ScheererJ
   - timebertt
-  - vlerenc
+  - vpnachev


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace vlerenc with vpnachev in TSC members

cc @vlerenc @ScheererJ @rfranzke @timebertt 

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/documentation/pull/1014

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
